### PR TITLE
Automatic nameserver updating upon vpn connection

### DIFF
--- a/etc/sudoers.d/tunnel-unpriv
+++ b/etc/sudoers.d/tunnel-unpriv
@@ -5,3 +5,5 @@
 tunnel ALL=(ALL) NOPASSWD: /bin/ip
 tunnel ALL=(ALL) NOPASSWD: /usr/sbin/openvpn *
 Defaults:tunnel !requiretty
+Defaults:tunnel env_keep += script_type
+Defaults:tunnel env_keep += dev

--- a/usr/lib/tmpfiles.d/50_openvpn-unpriv.conf
+++ b/usr/lib/tmpfiles.d/50_openvpn-unpriv.conf
@@ -1,1 +1,3 @@
 d       /run/openvpn    0755    tunnel    tunnel    -       -
+d       /run/resolvconf 0775    root      tunnel    -       -
+d       /run/resolvconf/interface         0775      root    tunnel    -    -


### PR DESCRIPTION
I modified the `tunnel-unpriv` sudoers file to preserve the environmental variables `script_type` and `dev` which are set in `openvpn.conf` Also, the tmp file `50_openvpn-unpriv.conf` was modified to preserve necessary resolvconf directory permissions through reboots. Commit tag is overly verbose as well.